### PR TITLE
SetObjectManager class and some messages

### DIFF
--- a/BlueBlur.h
+++ b/BlueBlur.h
@@ -202,6 +202,7 @@
 #include <Sonic/ObjectSystem/SetObjectListener.h>
 #include <Sonic/ObjectSystem/ObjectUtility/ObjectEdgeEmissionEffect.h>
 #include <Sonic/ObjectSystem/Renderable/RopeRenderable.h>
+#include <Sonic/ObjectSystem/Manager/SetObjectManager.h>
 #include <Sonic/Platform/D3D9/ApplicationD3D9.h>
 #include <Sonic/Platform/PC/ApplicationPC.h>
 #include <Sonic/Player/Character/Base/Player.h>

--- a/BlueBlur.h
+++ b/BlueBlur.h
@@ -189,6 +189,10 @@
 #include <Sonic/Message/MsgSetRotation.h>
 #include <Sonic/Message/MsgSetVisible.h>
 #include <Sonic/Message/MsgStartHomingChase.h>
+#include <Sonic/Message/MsgActivateLayer.h>
+#include <Sonic/Message/MsgDeactivateLayer.h>
+#include <Sonic/Message/MsgRemakeAllSetObject.h>
+#include <Sonic/Message/MsgStartCommonButtonSign.h>
 #include <Sonic/Object/ObjectBase.h>
 #include <Sonic/Object/Common/ObjUpReel/ObjUpReel.h>
 #include <Sonic/Object/Common/ObjWallJumpBlock/ObjWallJumpBlock.h>

--- a/Sonic/Message/MsgActivateLayer.h
+++ b/Sonic/Message/MsgActivateLayer.h
@@ -1,0 +1,18 @@
+﻿#pragma once
+
+#include <Hedgehog/Universe/Engine/hhMessage.h>
+
+namespace Sonic::Message
+{
+	class MsgActivateLayer : public Hedgehog::Universe::MessageTypeSet
+	{
+	public:
+		HH_FND_MSG_MAKE_TYPE(0x0167F0C0);
+		Hedgehog::base::CSharedString m_SetLayerName;
+		bool m_Field14;
+		MsgActivateLayer(const Hedgehog::base::CSharedString& in_SetLayerName, const bool in_Field14) : m_SetLayerName(in_SetLayerName), m_Field14(in_Field14) {}
+	};
+	BB_ASSERT_OFFSETOF(MsgActivateLayer, m_SetLayerName, 0x10);
+	BB_ASSERT_OFFSETOF(MsgActivateLayer, m_Field14, 0x14);
+	BB_ASSERT_SIZEOF(MsgActivateLayer, 0x18);
+}

--- a/Sonic/Message/MsgActivateLayer.h
+++ b/Sonic/Message/MsgActivateLayer.h
@@ -8,9 +8,9 @@ namespace Sonic::Message
 	{
 	public:
 		HH_FND_MSG_MAKE_TYPE(0x0167F0C0);
-		Hedgehog::base::CSharedString m_SetLayerName;
+		Hedgehog::Base::CSharedString m_SetLayerName;
 		bool m_Field14;
-		MsgActivateLayer(const Hedgehog::base::CSharedString& in_SetLayerName, const bool in_Field14) : m_SetLayerName(in_SetLayerName), m_Field14(in_Field14) {}
+		MsgActivateLayer(const Hedgehog::Base::CSharedString& in_rSetLayerName, const bool in_Field14) : m_SetLayerName(in_rSetLayerName), m_Field14(in_Field14) {}
 	};
 	BB_ASSERT_OFFSETOF(MsgActivateLayer, m_SetLayerName, 0x10);
 	BB_ASSERT_OFFSETOF(MsgActivateLayer, m_Field14, 0x14);

--- a/Sonic/Message/MsgDeactivateLayer.h
+++ b/Sonic/Message/MsgDeactivateLayer.h
@@ -4,12 +4,12 @@
 
 namespace Sonic::Message
 {
-	class MsgDeactivatelayer : public Hedgehog::Universe::MessageTypeSet
+	class MsgDeactivateLayer : public Hedgehog::Universe::MessageTypeSet
 	{
 	public:
 		HH_FND_MSG_MAKE_TYPE(0x0167F0D4);
-		Hedgehog::base::CSharedString m_SetLayerName;
-		MsgDeactivatelayer(const Hedgehog::base::CSharedString& in_SetLayerName) : m_SetLayerName(in_SetLayerName) {}
+		Hedgehog::Base::CSharedString m_SetLayerName;
+		MsgDeactivatelayer(const Hedgehog::Base::CSharedString& in_rSetLayerName) : m_SetLayerName(in_rSetLayerName) {}
 	};
 
 	BB_ASSERT_OFFSETOF(MsgDeactivatelayer, m_SetLayerName, 0x10);

--- a/Sonic/Message/MsgDeactivateLayer.h
+++ b/Sonic/Message/MsgDeactivateLayer.h
@@ -1,0 +1,17 @@
+﻿#pragma once
+
+#include <Hedgehog/Universe/Engine/hhMessage.h>
+
+namespace Sonic::Message
+{
+	class MsgDeactivatelayer : public Hedgehog::Universe::MessageTypeSet
+	{
+	public:
+		HH_FND_MSG_MAKE_TYPE(0x0167F0D4);
+		Hedgehog::base::CSharedString m_SetLayerName;
+		MsgDeactivatelayer(const Hedgehog::base::CSharedString& in_SetLayerName) : m_SetLayerName(in_SetLayerName) {}
+	};
+
+	BB_ASSERT_OFFSETOF(MsgDeactivatelayer, m_SetLayerName, 0x10);
+	BB_ASSERT_SIZEOF(MsgDeactivatelayer, 0x14);
+}

--- a/Sonic/Message/MsgRemakeAllSetObject.h
+++ b/Sonic/Message/MsgRemakeAllSetObject.h
@@ -1,0 +1,14 @@
+﻿#pragma once
+
+#include <Hedgehog/Universe/Engine/hhMessage.h>
+
+namespace Sonic::Message
+{
+	class MsgRemakeAllSetObject : public Hedgehog::Universe::MessageTypeSet
+	{
+	public:
+		HH_FND_MSG_MAKE_TYPE(0x0167EE98);
+		MsgRemakeAllSetObject() {}
+	};
+	BB_ASSERT_SIZEOF(MsgRemakeAllSetObject, 0x10);
+}

--- a/Sonic/Message/MsgStartCommonButtonSign.h
+++ b/Sonic/Message/MsgStartCommonButtonSign.h
@@ -1,0 +1,20 @@
+﻿#pragma once
+
+#include <Hedgehog/Universe/Engine/hhMessage.h>
+
+namespace Sonic::Message
+{
+	class MsgStartCommonButtonSign : public Hedgehog::Universe::MessageTypeSet
+	{
+	public:
+		HH_FND_MSG_MAKE_TYPE(0x01680730);
+		int32_t m_ButtonType;
+		int32_t m_ButtonType2;
+		int32_t m_Direction;
+		MsgStartCommonButtonSign(const int32_t in_ButtonType, const int32_t in_ButtonType2, const int32_t in_Direction) : m_ButtonType(in_ButtonType), m_ButtonType2(in_ButtonType2), m_Direction(in_Direction) {}
+	};
+	BB_ASSERT_OFFSETOF(MsgStartCommonButtonSign, m_ButtonType, 0x10);
+	BB_ASSERT_OFFSETOF(MsgStartCommonButtonSign, m_ButtonType2, 0x14);
+	BB_ASSERT_OFFSETOF(MsgStartCommonButtonSign, m_Direction, 0x18);
+	BB_ASSERT_SIZEOF(MsgStartCommonButtonSign, 0x1C);
+}

--- a/Sonic/ObjectSystem/Manager/SetObjectManager.h
+++ b/Sonic/ObjectSystem/Manager/SetObjectManager.h
@@ -8,7 +8,7 @@ namespace Sonic
     class CSetObjectManager
     {
     public:
-        class CSetObjectManagerMember
+        class CMember
         {
         public:
             BB_INSERT_PADDING(0x30);
@@ -19,13 +19,12 @@ namespace Sonic
             boost::shared_ptr<CSetObjectEventManager> m_spSetObjectEventManager;
         };
 
-        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spUserIDGroupCategoryManager, 0x38);
-        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spParameterBankManager, 0x40);
-        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spSetLayerManager, 0x50);
-        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spSetObjectEventManager, 0x58);
-
         BB_INSERT_PADDING(0xAC);
-        CSetObjectManagerMember* m_pMember;
+        CMember* m_pMember;
     };
     BB_ASSERT_OFFSETOF(CSetObjectManager, m_pMember, 0xAC);
+    BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spUserIDGroupCategoryManager, 0x38);
+    BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spParameterBankManager, 0x40);
+    BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spSetLayerManager, 0x50);
+    BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spSetObjectEventManager, 0x58);
 }

--- a/Sonic/ObjectSystem/Manager/SetObjectManager.h
+++ b/Sonic/ObjectSystem/Manager/SetObjectManager.h
@@ -19,10 +19,13 @@ namespace Sonic
             boost::shared_ptr<CSetObjectEventManager> m_spSetObjectEventManager;
         };
 
+        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spUserIDGroupCategoryManager, 0x38);
+        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spParameterBankManager, 0x40);
         BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spSetLayerManager, 0x50);
+        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spSetObjectEventManager, 0x58);
+
         BB_INSERT_PADDING(0xAC);
         CSetObjectManagerMember* m_pMember;
     };
-
     BB_ASSERT_OFFSETOF(CSetObjectManager, m_pMember, 0xAC);
 }

--- a/Sonic/ObjectSystem/Manager/SetObjectManager.h
+++ b/Sonic/ObjectSystem/Manager/SetObjectManager.h
@@ -1,0 +1,28 @@
+#pragma once
+namespace Sonic
+{
+    class CUserIDGroupCategoryManager;
+    class CParameterBankManager;
+    class CSetLayerManager;
+    class CSetObjectEventManager;
+    class CSetObjectManager
+    {
+    public:
+        class CSetObjectManagerMember
+        {
+        public:
+            BB_INSERT_PADDING(0x30);
+            boost::shared_ptr<CUserIDGroupCategoryManager> m_spUserIDGroupCategoryManager;
+            boost::shared_ptr<CParameterBankManager> m_spParameterBankManager;
+            BB_INSERT_PADDING(0x10);
+            boost::shared_ptr<CSetLayerManager> m_spSetLayerManager;
+            boost::shared_ptr<CSetObjectEventManager> m_spSetObjectEventManager;
+        };
+
+        BB_ASSERT_OFFSETOF(CSetObjectManagerMember, m_spSetLayerManager, 0x50);
+        BB_INSERT_PADDING(0xAC);
+        CSetObjectManagerMember* m_pMember;
+    };
+
+    BB_ASSERT_OFFSETOF(CSetObjectManager, m_pMember, 0xAC);
+}


### PR DESCRIPTION
This pull request contains a partial mapping of the SetObjectManager class, which is used in game to do things such as loading, enabling and disabling Set layers, saving layers and object parameters, and also launch a missing SetEditor object.
It also contains a couple of message definitions related to it and one that isn't related at all, which are: MsgActivateLayer, MsgDeactivateLayer, MsgRemakeAllSetObject, and MsgStartCommonButtonSign

Let me know if I need to change anything, as this is the first time I've tried doing things for BlueBlur! 😄