### PR TITLE
Renamed SetObjectListener functions and SetObjectManager update

### DIFF
--- a/Sonic/ObjectSystem/Manager/SetObjectManager.h
+++ b/Sonic/ObjectSystem/Manager/SetObjectManager.h
@@ -15,19 +15,19 @@ namespace Sonic
         class CMember
         {
         public:
-            BB_INSERT_PADDING(0x30);
-            //boost::shared_ptr<CSetObjectFactory> m_spSetObjectFactory;
+            BB_INSERT_PADDING(0x10);
+            boost::shared_ptr<Sonic::CSetObjectFactory> m_spSetObjectFactory;
+            BB_INSERT_PADDING(0x18);
             boost::shared_ptr<CUserIDGroupCategoryManager> m_spUserIDGroupCategoryManager;
             boost::shared_ptr<CParameterBankManager> m_spParameterBankManager;
             BB_INSERT_PADDING(0x10);
             boost::shared_ptr<CSetLayerManager> m_spSetLayerManager;
             boost::shared_ptr<CSetObjectEventManager> m_spSetObjectEventManager;
         };
-
         CMember* m_pMember;
     };
-
     BB_ASSERT_OFFSETOF(CSetObjectManager, m_pMember, 0xAC);
+    BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spSetObjectFactory, 0x10);
     BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spUserIDGroupCategoryManager, 0x30);
     BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spParameterBankManager, 0x38);
     BB_ASSERT_OFFSETOF(CSetObjectManager::CMember, m_spSetLayerManager, 0x50);

--- a/Sonic/ObjectSystem/SetObjectListener.h
+++ b/Sonic/ObjectSystem/SetObjectListener.h
@@ -21,8 +21,8 @@ namespace Sonic
         virtual void CSetObjectListener14(void*) {}
         virtual void CSetObjectListener18() {}
         virtual void CSetObjectListener1C(void*) {}
-        virtual void OnSetEditorStart() {}
-        virtual void OnSetEditorEnd() {}
+        virtual void OnEditEnter() {}
+        virtual void OnEditExit() {}
         virtual void CSetObjectListener28() {}
         virtual void CSetObjectListener2C() {}
         virtual void CSetObjectListener30(void*) {}

--- a/Sonic/ObjectSystem/SetObjectListener.h
+++ b/Sonic/ObjectSystem/SetObjectListener.h
@@ -21,8 +21,8 @@ namespace Sonic
         virtual void CSetObjectListener14(void*) {}
         virtual void CSetObjectListener18() {}
         virtual void CSetObjectListener1C(void*) {}
-        virtual void OnEditEnter() {}
-        virtual void OnEditExit() {}
+        virtual void OnSetEditorEnter() {}
+        virtual void OnSetEditorLeave() {}
         virtual void CSetObjectListener28() {}
         virtual void CSetObjectListener2C() {}
         virtual void CSetObjectListener30(void*) {}

--- a/Sonic/ObjectSystem/SetObjectListener.h
+++ b/Sonic/ObjectSystem/SetObjectListener.h
@@ -21,8 +21,8 @@ namespace Sonic
         virtual void CSetObjectListener14(void*) {}
         virtual void CSetObjectListener18() {}
         virtual void CSetObjectListener1C(void*) {}
-        virtual void CSetObjectListener20() {}
-        virtual void CSetObjectListener24() {}
+        virtual void OnSetEditorStart() {}
+        virtual void OnSetEditorEnd() {}
         virtual void CSetObjectListener28() {}
         virtual void CSetObjectListener2C() {}
         virtual void CSetObjectListener30(void*) {}


### PR DESCRIPTION
Hello again!
This PR renames 2 methods for SetObjectListener that happened to be used by the game when the SetEditor still existed, and it also maps out the location of SetObjectFactory in SetObjectManager's member class.
Hopefully this doesn't cause any issues 😅 