### PR TITLE
Add MainSequence, SequenceMode and ModeCreaterList

### DIFF
--- a/BlueBlur.h
+++ b/BlueBlur.h
@@ -253,6 +253,9 @@
 #include <Sonic/System/LightManager/LocalLight.h>
 #include <Sonic/System/RenderDirector/RenderDirector.h>
 #include <Sonic/System/RenderDirector/RenderDirectorFxPipeline.h>
+#include <Sonic/Sequence/SequenceModeBase.h>
+#include <Sonic/Sequence/SequenceMain.h>
+#include <Sonic/Sequence/ModeCreaterList.h>
 #include <Sonic/Tool/EditParam/EditParam.h>
 #include <Sonic/Tool/EditParam/FuncList.h>
 #include <Sonic/Tool/EditParam/ParamBase.h>

--- a/Sonic/Sequence/ModeCreaterList.h
+++ b/Sonic/Sequence/ModeCreaterList.h
@@ -1,20 +1,21 @@
-namespace Sonic
+#pragma once
+
+#include <Hedgehog/Base/Type/hhSharedString.h>
+
+namespace Sonic::Sequence
 {
-	namespace Sequence
+	class CModeCreaterListImpl
 	{
-		class CModeCreaterListImpl
-		{
-		public:
-			hh::map<Hedgehog::Base::CSharedString, boost::function<Sonic::Sequence::CSequenceMode* ()>> m_SequenceModes;
+	public:
+		hh::map<Hedgehog::Base::CSharedString, boost::function<Sonic::Sequence::CSequenceMode* ()>> m_SequenceModes;
 
-			virtual void CModeCreaterListImpl00(const char*, void*);
-			virtual boost::function<Sonic::Sequence::CSequenceMode*()> CModeCreaterListImpl04(const char*);
+		virtual void CModeCreaterListImpl00(const char*, void*);
+		virtual boost::function<Sonic::Sequence::CSequenceMode* ()> CModeCreaterListImpl04(const char*);
 
-			static inline CModeCreaterListImpl* ms_pInstance = (CModeCreaterListImpl*)0x01E78908;
-			static CModeCreaterListImpl* GetInstance();
-		};
-		BB_ASSERT_OFFSETOF(CModeCreaterListImpl, m_SequenceModes, 0x4);
-		BB_ASSERT_SIZEOF(CModeCreaterListImpl, 0x10);
-	}
+		static inline CModeCreaterListImpl* ms_pInstance = (CModeCreaterListImpl*)0x01E78908;
+		static CModeCreaterListImpl* GetInstance();
+	};
+	BB_ASSERT_OFFSETOF(CModeCreaterListImpl, m_SequenceModes, 0x4);
+	BB_ASSERT_SIZEOF(CModeCreaterListImpl, 0x10);
 }
 #include <Sonic/Sequence/ModeCreaterList.inl>

--- a/Sonic/Sequence/ModeCreaterList.h
+++ b/Sonic/Sequence/ModeCreaterList.h
@@ -1,0 +1,20 @@
+namespace Sonic
+{
+	namespace Sequence
+	{
+		class CModeCreaterListImpl
+		{
+		public:
+			hh::map<Hedgehog::Base::CSharedString, boost::function<Sonic::Sequence::CSequenceMode* ()>> m_SequenceModes;
+
+			virtual void CModeCreaterListImpl00(const char*, void*);
+			virtual boost::function<Sonic::Sequence::CSequenceMode*()> CModeCreaterListImpl04(const char*);
+
+			static inline CModeCreaterListImpl* ms_pInstance = (CModeCreaterListImpl*)0x01E78908;
+			static CModeCreaterListImpl* GetInstance();
+		};
+		BB_ASSERT_OFFSETOF(CModeCreaterListImpl, m_SequenceModes, 0x4);
+		BB_ASSERT_SIZEOF(CModeCreaterListImpl, 0x10);
+	}
+}
+#include <Sonic/Sequence/ModeCreaterList.inl>

--- a/Sonic/Sequence/ModeCreaterList.inl
+++ b/Sonic/Sequence/ModeCreaterList.inl
@@ -1,0 +1,10 @@
+namespace Sonic
+{
+	namespace Sequence
+	{
+		inline CModeCreaterListImpl* CModeCreaterListImpl::GetInstance()
+		{
+			return ms_pInstance;
+		}
+	}
+}

--- a/Sonic/Sequence/SequenceMain.h
+++ b/Sonic/Sequence/SequenceMain.h
@@ -1,4 +1,8 @@
 #pragma once
+
+#include <Hedgehog/Base/Type/hhSharedString.h>
+#include <Hedgehog/Universe/Engine/hhMessageActor.h>
+
 namespace Sonic::Sequence
 {
 	class CStoryImpl;

--- a/Sonic/Sequence/SequenceMain.h
+++ b/Sonic/Sequence/SequenceMain.h
@@ -1,0 +1,20 @@
+#pragma once
+namespace Sonic
+{
+	namespace Sequence
+	{		
+		class CStoryImpl;
+		class CSequenceMainImpl : public Hedgehog::Universe::CMessageActor
+		{
+		public:
+			Hedgehog::Base::CSharedString m_CurrentSequenceModeName;
+			boost::shared_ptr<CSequenceMode> m_spCurrentSequenceMode;
+			BB_INSERT_PADDING(0xC);
+			CStoryImpl* m_pStorySequence;
+			BB_INSERT_PADDING(0x8);
+		};
+		BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_CurrentSequenceModeName, 0x7C);
+		BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_spCurrentSequenceMode, 0x80);
+		BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_pStorySequence, 0x94);
+	}
+}

--- a/Sonic/Sequence/SequenceMain.h
+++ b/Sonic/Sequence/SequenceMain.h
@@ -1,20 +1,17 @@
 #pragma once
-namespace Sonic
+namespace Sonic::Sequence
 {
-	namespace Sequence
-	{		
-		class CStoryImpl;
-		class CSequenceMainImpl : public Hedgehog::Universe::CMessageActor
-		{
-		public:
-			Hedgehog::Base::CSharedString m_CurrentSequenceModeName;
-			boost::shared_ptr<CSequenceMode> m_spCurrentSequenceMode;
-			BB_INSERT_PADDING(0xC);
-			CStoryImpl* m_pStorySequence;
-			BB_INSERT_PADDING(0x8);
-		};
-		BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_CurrentSequenceModeName, 0x7C);
-		BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_spCurrentSequenceMode, 0x80);
-		BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_pStorySequence, 0x94);
-	}
+	class CStoryImpl;
+	class CSequenceMainImpl : public Hedgehog::Universe::CMessageActor
+	{
+	public:
+		Hedgehog::Base::CSharedString m_CurrentSequenceModeName;
+		boost::shared_ptr<CSequenceMode> m_spCurrentSequenceMode;
+		BB_INSERT_PADDING(0xC);
+		CStoryImpl* m_pStorySequence;
+		BB_INSERT_PADDING(0x8);
+	};
+	BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_CurrentSequenceModeName, 0x7C);
+	BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_spCurrentSequenceMode, 0x80);
+	BB_ASSERT_OFFSETOF(CSequenceMainImpl, m_pStorySequence, 0x94);
 }

--- a/Sonic/Sequence/SequenceModeBase.h
+++ b/Sonic/Sequence/SequenceModeBase.h
@@ -1,0 +1,14 @@
+#pragma once
+namespace Sonic
+{
+	namespace Sequence
+	{
+		class CSequenceMode : public Hedgehog::Universe::CMessageActor
+		{
+		public:
+			virtual void CSequenceMode04();
+			virtual void ChangeModule();
+			virtual void EndModule();
+		};
+	}
+}

--- a/Sonic/Sequence/SequenceModeBase.h
+++ b/Sonic/Sequence/SequenceModeBase.h
@@ -1,14 +1,14 @@
 #pragma once
-namespace Sonic
+
+#include <Hedgehog/Universe/Engine/hhMessageActor.h>
+
+namespace Sonic::Sequence
 {
-	namespace Sequence
+	class CSequenceMode : public Hedgehog::Universe::CMessageActor
 	{
-		class CSequenceMode : public Hedgehog::Universe::CMessageActor
-		{
-		public:
-			virtual void CSequenceMode10();
-			virtual void ChangeModule();
-			virtual void EndModule();
-		};
-	}
+	public:
+		virtual void CSequenceMode10();
+		virtual void ChangeModule();
+		virtual void EndModule();
+	};
 }

--- a/Sonic/Sequence/SequenceModeBase.h
+++ b/Sonic/Sequence/SequenceModeBase.h
@@ -6,7 +6,7 @@ namespace Sonic
 		class CSequenceMode : public Hedgehog::Universe::CMessageActor
 		{
 		public:
-			virtual void CSequenceMode04();
+			virtual void CSequenceMode10();
 			virtual void ChangeModule();
 			virtual void EndModule();
 		};


### PR DESCRIPTION
MainSequence (Sonic::Sequence::CSequenceMainImpl) is the class that manages MainSequence.lua and the module system

SequenceMode (Sonic::Sequence::CSequenceMode) is a class thats used to manage changing and ending GameplayFlows (gamemodes), ChangeModule will cause the game to switch the active gamemode to itself, and EndModule will end it

ModeCreaterList (Sonic::Sequence::CModeCreaterListImpl) is a class that's only used for managing SequenceModes
