### PR TITLE
Added Message category map to CMessageManager

### DIFF
--- a/Hedgehog/Universe/Engine/hhMessageManager.h
+++ b/Hedgehog/Universe/Engine/hhMessageManager.h
@@ -16,12 +16,14 @@ namespace Hedgehog::Universe
     {
     public:
         hh::map<size_t, CMessageActor*> m_MessageActorMap;
+        hh::map<Hedgehog::Base::CSharedString, hh::list<CMessageActor*>> m_CategoryMap;
 
         CMessageActor* GetMessageActor(size_t in_ActorID) const;
         bool AddMessageActor(const Hedgehog::Base::CSharedString& in_rCategory, CMessageActor* in_pMessageActor);
     };
 
     BB_ASSERT_OFFSETOF(CMessageManager, m_MessageActorMap, 0x4);
+    BB_ASSERT_OFFSETOF(CMessageManager, m_CategoryMap, 0x10);
 }
 
 #include <Hedgehog/Universe/Engine/hhMessageManager.inl>


### PR DESCRIPTION
Just what the request name says, adds a map for message categories to CMessageManager
I pulled the name m_CategoryMap from SWA preview build 1