### PR TITLE
Remove assertions from Sonic::CParamValue

### DIFF
--- a/Sonic/Tool/EditParam/ParamValue.h
+++ b/Sonic/Tool/EditParam/ParamValue.h
@@ -19,15 +19,5 @@ namespace Sonic
 
         FuncData* m_pFuncData;
         T m_DefaultValue;
-
-        BB_ASSERT_OFFSETOF(FuncData, m_pValue, 0x8);
-        BB_ASSERT_OFFSETOF(FuncData, m_Value, 0xC);
-        BB_ASSERT_OFFSETOF(FuncData, m_ChangedCallback, 0x10);
-        BB_ASSERT_OFFSETOF(FuncData, m_Field30, 0x30);
-        BB_ASSERT_SIZEOF(FuncData, 0x38);
-
-        BB_ASSERT_OFFSETOF(CParamValue, m_pFuncData, 0x14);
-        BB_ASSERT_OFFSETOF(CParamValue, m_DefaultValue, 0x18);
-        BB_ASSERT_SIZEOF(CParamValue, 0x1C);
     };
 }


### PR DESCRIPTION
These assertions always fail on latest MSVC, possibly due to the template type's size being evaluated differently. The offsets and sizes aren't guaranteed anyway, as they'll shift if the template type isn't 32-bits wide.